### PR TITLE
Enable battery charge limit on Slimbook models (EVO14 BIOS version fails feature detection)

### DIFF
--- a/features.c
+++ b/features.c
@@ -22,9 +22,10 @@ struct oem_string_walker_data {
 
 static int __init slimbook_dmi_cb(const struct dmi_system_id *id)
 {
-	qc71_features.fn_lock      = true;
-	qc71_features.silent_mode  = true;
-	qc71_features.turbo_mode   = true;
+	qc71_features.fn_lock           = true;
+	qc71_features.silent_mode       = true;
+	qc71_features.turbo_mode        = true;
+	qc71_features.batt_charge_limit = true;
 
 	return 1;
 }


### PR DESCRIPTION
### Disclaimer
I worked with Claude Fable model to generate this PR, but it was heavily influenced by myself, and I had the itch of not wanting to reboot the machine to change the battery profile in linux.

I did the homework in terms of looking at the minimal changes required for this to work and actually test this on my Slimbook machine in multiple ways (by compiling new driver, checking battery charge, changing battery charge and seeing the battery actually charge, etc... I did several tests on the hardware, so this is not a simple PR that has been created with an IA, there's work and testing behind, but it is true that the heavy lifting is done by the IA). 

### Summary

On the Slimbook EVO14 (AMD Ryzen AI 9 365), the driver never exposes
`/sys/class/power_supply/BAT0/charge_control_end_threshold`, even though the
EC supports battery charge limiting — the BIOS has a working "limit charge to
60/80/100%" option, and the driver already contains the support code in
`battery.c` (EC register `0x07B9`).

This PR enables `batt_charge_limit` from the existing Slimbook DMI callback
(`slimbook_dmi_cb`), alongside the other vendor-wide features. **Tested on
hardware** — see *Testing* below.

### System information

| Field | Value |
|---|---|
| Model | SLIMBOOK EVO14-AI9-STP |
| CPU | AMD Ryzen AI 9 365 w/ Radeon 880M |
| BIOS version (DMI) | `N.1.20GOS02` |
| EC version | 1.18 |
| Kernel | 6.17.0-35-generic (Ubuntu 24.04 HWE) |
| Driver | `slimbook-qc71-dkms` 1.1.0 (this branch, `generic_slimbook`) |

### Root cause

The charge limit feature is currently only enabled by `check_features_bios()`
when the DMI BIOS version parses to ≥ 114. `parse_bios_version()` extracts the
digits between the first and second `.`, which assumes the older TongFang
format (e.g. `QCCFL357.0114.2020.0313.1530` → `114`):

```c
if (bios_version >= 114) {
        ...
        qc71_features.batt_charge_limit = true;
        ...
}
```

The EVO14 reports BIOS version `N.1.20GOS02`, which parses as `1`, so the
feature block is skipped and the `charge_control_end_threshold` attribute is
never registered. There is also no module parameter to force-enable it.

The EC `support_2` "MyBattery" bit (`SUPPORT_2_MY_BATTERY`) was considered as
a detection mechanism instead, but the EVO14 EC does not advertise it (tested:
the attribute does not appear when gating on that bit), so the DMI callback is
used, consistent with how `fn_lock`/`silent_mode`/`turbo_mode` are enabled.

### Testing

Built against kernel 6.17.0-35-generic and loaded on the EVO14-AI9-STP:

* `charge_control_end_threshold` now appears and reads the active limit
  (`60`, matching the limit previously set in BIOS setup).
* **Setting works:** `echo 80 > .../charge_control_end_threshold` — value reads
  back as `80` and, with the battery at ~60% on AC, status flips from
  `Not charging` to `Charging` within seconds. Lowering it back to `60` stops
  charging again.
* The BIOS-version path for older TongFang models is untouched; the DMI
  callback only ever sets the flag to true.