### PR TITLE
fix: enable batt_charge_limit for Slimbook EVO boards

### DIFF
--- a/features.c
+++ b/features.c
@@ -22,9 +22,14 @@ struct oem_string_walker_data {
 
 static int __init slimbook_dmi_cb(const struct dmi_system_id *id)
 {
-	qc71_features.fn_lock      = true;
-	qc71_features.silent_mode  = true;
-	qc71_features.turbo_mode   = true;
+	qc71_features.fn_lock           = true;
+	qc71_features.silent_mode       = true;
+	qc71_features.turbo_mode        = true;
+	/* Slimbook EVO BIOS version string (e.g. "N.1.20GOS04") does not parse
+	 * as an integer >= 114, so the generic bios version check never enables
+	 * this flag. The charge control register (0x07B9) is present on all
+	 * Slimbook EVO models — enable it unconditionally for SLIMBOOK boards. */
+	qc71_features.batt_charge_limit = true;
 
 	return 1;
 }


### PR DESCRIPTION
## Problem

Slimbook EVO laptops (confirmed on EVO15-AI9-STP, project id 26, platform id 72) fail to initialize the battery submodule with `-19` (ENODEV) on every boot:

```
qc71_laptop/main: qc71_laptop_module_init: failed to initialize battery submodule: -19
```

This means `/sys/class/power_supply/BAT0/charge_control_end_threshold` is never exposed, so no software charge limiting is possible.

## Root Cause

`battery_setup()` gates on `qc71_features.batt_charge_limit`, which is only set to `true` in `check_features_bios()` when `parse_bios_version()` returns `>= 114`.

Slimbook EVO uses a custom BIOS version string format: `N.1.20GOS04`. The parser extracts the number between the **first and second dot**, which is `1` — far below 114. The condition never passes, so `batt_charge_limit` stays `false`.

```c
/* QCCFL357.0062.2020.0313.1530 -> 62 */
static int __pure __init parse_bios_version(const char *str)
/* "N.1.20GOS04" -> 1, not >= 114 */
```

## Fix

Set `batt_charge_limit = true` in `slimbook_dmi_cb()`. The charge control EC register (`BATT_CHARGE_CTRL_ADDR`, `0x07B9`) is present and functional on Slimbook EVO hardware — confirmed by reading the register successfully after applying the patch.

## Verified on

- **Hardware:** Slimbook EVO15-AI9-STP (project id: 26, platform id: 72)
- **BIOS:** N.1.20GOS04 / EC 1.29
- **Kernel:** 7.0.11-76070011-generic (Pop!_OS 24.04)

After patch:
```
supported features: super-key-lock fan-boost fn-lock charge-limit silent-mode turbo-mode
/sys/class/power_supply/BAT0/charge_control_end_threshold → 80
battery state: pending-charge (charger correctly paused at limit)
```